### PR TITLE
Feat: Add version number to console output (Issue #5)

### DIFF
--- a/packages/redata_reports/run/main.py
+++ b/packages/redata_reports/run/main.py
@@ -42,6 +42,8 @@ def init_argparse():
 
 
 def run(args):
+    print(f'This is redata-reports version v{__version__} {__commit__}')
+    
     if args.sync_to_dashboard:
         args.units = 'B'
         args.report = ['items', 'users']

--- a/packages/redata_reports/run/main.py
+++ b/packages/redata_reports/run/main.py
@@ -43,7 +43,7 @@ def init_argparse():
 
 def run(args):
     print(f'This is redata-reports version v{__version__} {__commit__}')
-    
+
     if args.sync_to_dashboard:
         args.units = 'B'
         args.report = ['items', 'users']


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR addresses the feature/enhancement. -->

Display the version number somewhere to make it easy to see which version generated the logs.

<!-- Add any related issues or pull requests -->
See #5

**Documentation Update**

 - [ ] I have updated README.md and other relevant documentation
 - [x] No documentation update is needed

*Implementation Notes*
Originally, the idea was to place the version in an environment variable so it would show up in DO. However, DO encrypts env variables so instead, the version is output to the console. This output appears in the DO execution logs.
