### PR TITLE
Feat: Add reports for stats from Trello (Issue #19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+#lib/
 lib64/
 parts/
 sdist/

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-doctl serverless deploy . --remote-build --env packages/redata_reports/run/secrets.py
+doctl serverless deploy . --remote-build --env lib/secrets.py

--- a/lib/functions.py
+++ b/lib/functions.py
@@ -11,7 +11,7 @@ def get_request_headers():
     Returns the headers to use for the figshare requests.get calls
     """
     headers = {'Content-Type': 'application/json',
-               'Authorization': 'Bearer {0}'.format(environ['API_TOKEN'])}
+               'Authorization': 'Bearer {0}'.format(environ['API_FIGSHARE_TOKEN'])}
     return headers
 
 

--- a/lib/secrets.example.py
+++ b/lib/secrets.example.py
@@ -5,8 +5,13 @@
 from os import environ
 
 # Figshare API
-api_url_base = ''
-api_token = ''
+api_figshare_url_base = ''
+api_figshare_token = ''
+
+# Trello API
+api_trello_url_base = ''
+api_trello_key = ''
+api_trello_token = ''
 
 # Google sheet
 gsheets_dashboard_post_url = ''
@@ -14,11 +19,3 @@ gsheets_dashboard_key = ''
 
 # DO access token. When deployed as a function, all requests must send this token in the 't' parameter of the GET request
 do_token = ''
-
-
-# **************************************************************
-environ['API_URL_BASE'] = api_url_base
-environ['API_TOKEN'] = api_token
-environ['GSHEETS_DASHBOARD_POST_URL'] = gsheets_dashboard_post_url
-environ['GSHEETS_DASHBOARD_KEY'] = gsheets_dashboard_key
-environ['TOKEN'] = do_token

--- a/packages/redata_reports/run/build.sh
+++ b/packages/redata_reports/run/build.sh
@@ -7,4 +7,5 @@ set -e
 virtualenv virtualenv
 source virtualenv/bin/activate
 pip install -r requirements.txt
+cp ../../../lib/*.py .
 deactivate

--- a/packages/redata_reports/run/items_report.py
+++ b/packages/redata_reports/run/items_report.py
@@ -4,11 +4,14 @@
 #
 # Author: Fernando Rios
 
+import sys
 import requests
 import simplejson as json
 from multiprocessing import Pool
 from datetime import datetime
 from os import environ
+
+sys.path.insert(0, 'lib/')
 import functions as f
 
 
@@ -16,7 +19,7 @@ def get_institution_articles():
     page = 1
     article_list = []
     while True:
-        api_url = '{0}/account/institution/articles?page={1}&page_size=1000'.format(environ['API_URL_BASE'], page)
+        api_url = '{0}/account/institution/articles?page={1}&page_size=1000'.format(environ['API_FIGSHARE_URL_BASE'], page)
         page += 1
         response = requests.get(api_url, headers=f.get_request_headers())
 
@@ -37,14 +40,14 @@ def get_public_article_info(article_ids):
         article_ids = [article_ids]
 
     for id in article_ids:
-        api_url = '{0}/articles/{1}/versions'.format(environ['API_URL_BASE'], id)
+        api_url = '{0}/articles/{1}/versions'.format(environ['API_FIGSHARE_URL_BASE'], id)
         response = requests.get(api_url, headers=f.get_request_headers())
         if response.status_code == 200:
             article_versions = json.loads(response.text)
             if len(article_versions) > 0:
                 for version in article_versions:
                     version_num = version['version']
-                    api_url = '{0}/articles/{1}/versions/{2}'.format(environ['API_URL_BASE'], id, version_num)
+                    api_url = '{0}/articles/{1}/versions/{2}'.format(environ['API_FIGSHARE_URL_BASE'], id, version_num)
                     response = requests.get(api_url, headers=f.get_request_headers())
 
                     if response.status_code == 200:
@@ -69,7 +72,7 @@ def get_private_article_info(article_ids):
         article_ids = [article_ids]
 
     for id in article_ids:
-        api_url = '{0}/account/articles/{1}'.format(environ['API_URL_BASE'], id)
+        api_url = '{0}/account/articles/{1}'.format(environ['API_FIGSHARE_URL_BASE'], id)
         response = requests.get(api_url, headers=f.get_request_headers())
         if response.status_code == 200:
             article_info.append(json.loads(response.text))

--- a/packages/redata_reports/run/main.py
+++ b/packages/redata_reports/run/main.py
@@ -5,12 +5,15 @@
 # Author: Fernando Rios
 
 import argparse
+import sys
 from os import environ
 from version import __version__, __commit__
-import secrets
-import functions as f
 import items_report
 import userquota_report
+
+sys.path.insert(0, 'lib/')
+import functions as f
+import secrets
 
 
 def init_argparse():
@@ -36,7 +39,7 @@ def init_argparse():
     )
     parser.add_argument(
         '-u', '--units', choices=['B', 'KB', 'MB', 'GB', 'TB'],
-        default='GB', help='Set the output units. Default is %(default)s')
+        default='GB', help='Set the output size units. Default is %(default)s')
 
     return parser
 
@@ -71,8 +74,8 @@ def run(args):
 if __name__ == '__main__':
     args = init_argparse().parse_args()
 
-    environ['API_URL_BASE'] = secrets.api_url_base
-    environ['API_TOKEN'] = secrets.api_token
+    environ['API_FIGSHARE_URL_BASE'] = secrets.api_figshare_url_base
+    environ['API_FIGSHARE_TOKEN'] = secrets.api_figshare_token
     environ['GSHEETS_DASHBOARD_POST_URL'] = secrets.gsheets_dashboard_post_url
     environ['GSHEETS_DASHBOARD_KEY'] = secrets.gsheets_dashboard_key
     environ['TOKEN'] = secrets.do_token

--- a/packages/redata_reports/run/userquota_report.py
+++ b/packages/redata_reports/run/userquota_report.py
@@ -8,10 +8,13 @@
 #
 # Author: Fernando Rios
 
+import sys
 import requests
 import simplejson as json
 from multiprocessing import Pool
 from os import environ
+
+sys.path.insert(0, 'lib/')
 import functions as f
 
 
@@ -19,7 +22,7 @@ def get_institution_accounts():
     page = 1
     accounts_list = []
     while True:
-        api_url = '{0}/account/institution/accounts?page={1}&page_size=1000'.format(environ['API_URL_BASE'], page)
+        api_url = '{0}/account/institution/accounts?page={1}&page_size=1000'.format(environ['API_FIGSHARE_URL_BASE'], page)
         page += 1
         response = requests.get(api_url, headers=f.get_request_headers())
 
@@ -33,14 +36,14 @@ def get_institution_accounts():
 
 
 def get_account_info(id):
-    api_url = '{0}/account?impersonate={1}'.format(environ['API_URL_BASE'], id)
+    api_url = '{0}/account?impersonate={1}'.format(environ['API_FIGSHARE_URL_BASE'], id)
     response = requests.get(api_url, headers=f.get_request_headers())
 
     if response.status_code == 200:
         data = json.loads(response.text)
     elif response.status_code == 403:
         # can't impersonate ourselves
-        api_url = '{0}/account'.format(environ['API_URL_BASE'])
+        api_url = '{0}/account'.format(environ['API_FIGSHARE_URL_BASE'])
         response = requests.get(api_url, headers=f.get_request_headers())
         data = json.loads(response.text)
     else:

--- a/packages/redata_reports/run/version.py
+++ b/packages/redata_reports/run/version.py
@@ -14,4 +14,4 @@ def get_commit(repo_path):
 
 
 __commit__ = get_commit('.')
-__version__ = '1.1.1'
+__version__ = '1.1.2'

--- a/packages/trello_reports/run/.ignore
+++ b/packages/trello_reports/run/.ignore
@@ -1,0 +1,2 @@
+# These files will not be included in the DO deployed package
+secrets*

--- a/packages/trello_reports/run/__main__.py
+++ b/packages/trello_reports/run/__main__.py
@@ -1,0 +1,26 @@
+# Entry point for DO functions
+
+import main as m
+from os import environ
+
+
+def main(event, context):
+    # Only allow authenticated requests
+    accesstoken = event.get("t", "")
+    if accesstoken != environ["TOKEN"]:
+        return {
+            "headers": {"Content-Type": "text/html"},
+            "statusCode": 403,
+            "body": "Forbidden. Invalid token."
+        }
+
+    args = m.init_argparse().parse_args()
+    args.sync_to_dashboard = True
+
+    result = m.run(args)
+
+    return {
+        "headers": {"Content-Type": "text/html"},
+        "statusCode": 200,
+        "body": f"{result}"
+    }

--- a/packages/trello_reports/run/build.sh
+++ b/packages/trello_reports/run/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Script for remote DO builds
+
+set -e
+
+virtualenv virtualenv
+source virtualenv/bin/activate
+pip install -r requirements.txt
+cp ../../../lib/*.py .
+deactivate

--- a/packages/trello_reports/run/main.py
+++ b/packages/trello_reports/run/main.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+# Runs various reports for ReDATA
+#
+# Author: Fernando Rios
+
+import argparse
+import sys
+from os import environ
+from version import __version__, __commit__
+#import items_report
+
+sys.path.insert(0, 'lib/')
+import functions as f
+import secrets
+
+def init_argparse():
+    parser = argparse.ArgumentParser(
+        description='Runs reports for Trello stats'
+    )
+    parser.add_argument(
+        '-r', '--report', required=False, action='append', choices=['curators', 'items'],
+        help="Selects which report to run. This option can appear more than once"
+    )
+    parser.add_argument(
+        '--sync-to-dashboard', required=False, action='store_true',
+        help="Uploads report data to the Google dashboard. Additionally, sets these flags: -u B -r items -r users"
+    )
+    parser.add_argument(
+        '-v', '--version', action='version',
+        version=f'{parser.prog} v{__version__} {__commit__}'
+    )
+    parser.add_argument(
+        '-o', '--outfile', metavar='PATH', nargs='?',
+        const=f"$$*$${f.get_report_date().strftime('%Y-%m-%dT%H%M%S')}.csv",
+        type=str, help="Write output to a file. If PATH isn't specified, file will default to a timestamped file in the current directory"
+    )
+    parser.add_argument(
+        '-u', '--units', choices=['M', 'W', 'D', 'H', 'm', 's'],
+        default='H', help='Set the output time units. Default is %(default)s')
+
+    return parser
+
+
+def run(args):
+    print(f'This is trello-reports version v{__version__} {__commit__}')
+
+    if args.sync_to_dashboard:
+        args.units = 's'
+        args.report = ['curators', 'items']
+
+    if not args.report:
+        return 'No report specified. Doing nothing'
+
+    result = ''
+    if 'curators' in args.report:
+        print('Running "curators" report')
+        result = f.get_report_date()
+        #data = curator_report.run(args)
+        #result = result + f'Running "curator" report completed. {len(data)} curators.'
+        #if args.sync_to_dashboard:
+        #    result = result + f'\nSyncing "curator" to dashboard completed. Result: {f.sync_to_dashboard(data, "curator")}.'
+    if 'items' in args.report:
+        print('Running "items" report')
+        result = 'not implemented'
+
+    return result
+
+
+if __name__ == '__main__':
+    args = init_argparse().parse_args()
+
+    environ['API_TRELLO_URL_BASE'] = secrets.api_trello_url_base
+    environ['API_TRELLO_KEY'] = secrets.api_trello_key
+    environ['API_TRELLO_TOKEN'] = secrets.api_trello_token
+    environ['GSHEETS_DASHBOARD_POST_URL'] = secrets.gsheets_dashboard_post_url
+    environ['GSHEETS_DASHBOARD_KEY'] = secrets.gsheets_dashboard_key
+    environ['TOKEN'] = secrets.do_token
+
+    print(run(args))

--- a/packages/trello_reports/run/requirements.txt
+++ b/packages/trello_reports/run/requirements.txt
@@ -1,0 +1,2 @@
+requests
+simplejson

--- a/packages/trello_reports/run/version.py
+++ b/packages/trello_reports/run/version.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def get_commit(repo_path):
+    # https://stackoverflow.com/a/68215738
+    git_folder = Path(repo_path, '../../../.git')
+    try:
+        head_name = Path(git_folder, 'HEAD').read_text().split('\n')[0].split(' ')[-1]
+        head_ref = Path(git_folder, head_name)
+        commit = head_ref.read_text().replace('\n', '')
+    except Exception:
+        return ''
+    return commit
+
+
+__commit__ = get_commit('.')
+__version__ = '1.0.0'

--- a/project.yml
+++ b/project.yml
@@ -13,3 +13,18 @@ packages:
           GSHEETS_DASHBOARD_POST_URL: ${gsheets_dashboard_post_url}
           GSHEETS_DASHBOARD_KEY: ${gsheets_dashboard_key}
           TOKEN: ${do_token}
+  - name: trello_reports
+    functions:
+      - name: run
+        runtime: 'python:default'
+        web: true
+        limits:
+          timeout: 420000
+          memory: 512
+        environment:
+          API_TRELLO_URL_BASE: ${api_trello_url_base}
+          API_TRELLO_KEY: ${api_trello_key}
+          API_TRELLO_TOKEN: ${api_trello_token}
+          GSHEETS_DASHBOARD_POST_URL: ${gsheets_dashboard_post_url}
+          GSHEETS_DASHBOARD_KEY: ${gsheets_dashboard_key}
+          TOKEN: ${do_token}

--- a/project.yml
+++ b/project.yml
@@ -8,8 +8,8 @@ packages:
           timeout: 420000
           memory: 512
         environment:
-          API_URL_BASE: ${api_url_base}
-          API_TOKEN: ${api_token}
+          API_FIGSHARE_URL_BASE: ${api_figshare_url_base}
+          API_FIGSHARE_TOKEN: ${api_figshare_token}
           GSHEETS_DASHBOARD_POST_URL: ${gsheets_dashboard_post_url}
           GSHEETS_DASHBOARD_KEY: ${gsheets_dashboard_key}
           TOKEN: ${do_token}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
Uses the same scaffolding as the existing redata_reports to gather data from Trello to send to the LookerStudio Dashboard. The overall code was refactored to enable some reuse of secrets and general utility functions by leveraging DO's `lib/` folder (refer to the DO build [process documentation](https://docs.digitalocean.com/products/functions/reference/build-process/) for how it works. 

<!-- Add any related issues or pull requests -->
See #19

**Documentation Update**

 - [ ] I have updated README.md and other relevant documentation
 - [ ] No documentation update is needed

*Implementation Notes*
When running locally, the shared functions are loaded by adding `lib/` to the path Python looks for modules in using `sys.append`. When deployed to DO, the build script copies the files in that folder to the same directory as the function. The `sys.append` line is still there but does nothing since the files will all be in the same folder.
